### PR TITLE
Missing apostrophes for file paths with spaces.

### DIFF
--- a/.kick
+++ b/.kick
@@ -4,7 +4,7 @@ Kicker::Recipes::Ruby.runner_bin = 'bacon -q'
 process do |potential_files|
   files = potential_files.take_and_map do |file|
       if file =~ %r{^.*\.(m|xib|strings)$}
-        execute("/usr/bin/python #{File.expand_path("~/.dyci/scripts/dyci-recompile.py")} #{"\"%s\"" % File.expand_path(file)}")
+        execute("/usr/bin/python #{File.expand_path("~/.dyci/scripts/dyci-recompile.py")} '#{"\"%s\"" % File.expand_path(file)}'")
         puts "KZPlayground: Recompiled #{file}"
         file
       end

--- a/.kick
+++ b/.kick
@@ -4,7 +4,7 @@ Kicker::Recipes::Ruby.runner_bin = 'bacon -q'
 process do |potential_files|
   files = potential_files.take_and_map do |file|
       if file =~ %r{^.*\.(m|xib|strings)$}
-        execute("/usr/bin/python #{File.expand_path("~/.dyci/scripts/dyci-recompile.py")} #{File.expand_path(file)}")
+        execute("/usr/bin/python #{File.expand_path("~/.dyci/scripts/dyci-recompile.py")} #{"\"%s\"" % File.expand_path(file)}")
         puts "KZPlayground: Recompiled #{file}"
         file
       end

--- a/KZPlayground.podspec
+++ b/KZPlayground.podspec
@@ -31,7 +31,7 @@ Kicker::Recipes::Ruby.runner_bin = 'bacon -q'
 process do |potential_files|
   files = potential_files.take_and_map do |file|
       if file =~ %r{^.*\.(m|xib|strings)$}
-        execute("/usr/bin/python #{File.expand_path("~/.dyci/scripts/dyci-recompile.py")} #{File.expand_path(file)}")
+        execute("/usr/bin/python #{File.expand_path("~/.dyci/scripts/dyci-recompile.py")} '#{File.expand_path(file)}'")
         puts "KZPlayground: Recompiled #{file}"
         file
       end


### PR DESCRIPTION
I added the missing apostrophes in prepare_command podspec, to handle file paths with spaces in kicker.