### PR TITLE
Fix paths with spaces not passes properly to dyci script

### DIFF
--- a/.kick
+++ b/.kick
@@ -4,7 +4,12 @@ Kicker::Recipes::Ruby.runner_bin = 'bacon -q'
 process do |potential_files|
   files = potential_files.take_and_map do |file|
       if file =~ %r{^.*\.(m|xib)$}
-        execute("/usr/bin/python #{File.expand_path("~/.dyci/scripts/dyci-recompile.py")} #{File.expand_path(file)}")
+        cmd = ['/usr/bin/python']
+        cmd << File.expand_path('~/.dyci/scripts/dyci-recompile.py').safe_shell_path
+        cmd << File.expand_path(file).safe_shell_path
+
+        command = cmd.join(' ')
+        execute(command)
         puts "KZPlayground: Recompiled #{file}"
         file
       end
@@ -20,4 +25,10 @@ end
 
 startup do
   log "KZPlayground: Watching for file changes!"
+end
+
+class String
+  def safe_shell_path
+    "\"#{self}\""
+  end
 end

--- a/KZPlayground.podspec
+++ b/KZPlayground.podspec
@@ -22,7 +22,7 @@ Fast robust interations make it easy to prototype custom UI/Algorithms or even l
   s.dependency 'dyci', '~> 0.1.5.6'
   s.dependency 'RSSwizzle', '~> 0.1.0'
 
-  s.prepare_command = <<-'CMD' 
+  s.prepare_command = <<-'CMD'
   cat << EOF > ../../.kick
    recipe :ruby
 Kicker::Recipes::Ruby.runner_bin = 'bacon -q'
@@ -30,7 +30,12 @@ Kicker::Recipes::Ruby.runner_bin = 'bacon -q'
 process do |potential_files|
   files = potential_files.take_and_map do |file|
       if file =~ %r{^.*\.(m)$}
-        execute("/usr/bin/python #{File.expand_path("~/.dyci/scripts/dyci-recompile.py")} #{File.expand_path(file)}")
+        cmd = ['/usr/bin/python']
+        cmd << File.expand_path('~/.dyci/scripts/dyci-recompile.py').safe_shell_path
+        cmd << File.expand_path(file).safe_shell_path
+
+        command = cmd.join(' ')
+        execute(command)
         puts "KZPlayground: Recompiled #{file}"
         file
       end
@@ -46,6 +51,12 @@ end
 
 startup do
   log "KZPlayground: Watching for file changes!"
+end
+
+class String
+  def safe_shell_path
+    "\"#{self}\""
+  end
 end
 EOF
 CMD


### PR DESCRIPTION
Bash paths should be surrounded with quotes, as if you have paths with spaces script will fail passing incorrect path to dyci